### PR TITLE
Spec library: 10 specs for eval

### DIFF
--- a/specs/bounded_queue.md
+++ b/specs/bounded_queue.md
@@ -1,0 +1,45 @@
+# Spec: bounded_queue
+
+## Description
+A thread-safe blocking queue with a maximum size. Put blocks when full,
+get blocks when empty, with optional timeouts on both operations.
+
+## Signature
+```python
+class bounded_queue:
+    def __init__(self, maxsize: int) -> None: ...
+    def put(self, item: object, timeout: float | None = None) -> None: ...
+    def get(self, timeout: float | None = None) -> object: ...
+    def size(self) -> int: ...
+    def empty(self) -> bool: ...
+    def full(self) -> bool: ...
+```
+
+## Behavior
+- `__init__` creates an empty queue with the given maximum size
+- `put(item)` adds item to the queue; blocks if queue is full until space is available
+- `put(item, timeout=N)` blocks for at most N seconds; raises `QueueFullError` if still full after timeout
+- `get()` removes and returns the oldest item; blocks if queue is empty until an item is available
+- `get(timeout=N)` blocks for at most N seconds; raises `QueueEmptyError` if still empty after timeout
+- `size()` returns current number of items
+- `empty()` returns True if queue has no items
+- `full()` returns True if queue has reached maxsize
+- `QueueFullError` and `QueueEmptyError` are custom exceptions defined in the same module
+- Must be thread-safe: use `threading.Lock` and `threading.Condition`
+- Items are returned in FIFO order
+
+## Examples
+```python
+q = bounded_queue(2)
+q.put("a")
+q.put("b")
+assert q.full() is True
+assert q.get() == "a"  # FIFO
+```
+
+## Tests
+- test_fifo_order: items returned in insertion order
+- test_blocks_when_full: put with timeout raises QueueFullError on full queue
+- test_blocks_when_empty: get with timeout raises QueueEmptyError on empty queue
+- test_thread_safety: concurrent put and get from multiple threads
+- test_size_empty_full: size/empty/full reflect queue state correctly

--- a/specs/circuit_breaker.md
+++ b/specs/circuit_breaker.md
@@ -1,0 +1,46 @@
+# Spec: circuit_breaker
+
+## Description
+A circuit breaker that wraps a callable. Tracks consecutive failures and
+transitions between closed (allowing calls), open (blocking calls), and
+half-open (allowing a single test call) states.
+
+## Signature
+```python
+class circuit_breaker:
+    def __init__(self, failure_threshold: int = 3, recovery_timeout: float = 5.0) -> None: ...
+    def call(self, func: Callable, *args, **kwargs) -> object: ...
+    @property
+    def state(self) -> str: ...
+```
+
+## Behavior
+- Starts in "closed" state (calls pass through normally)
+- In "closed" state: if `func` raises an exception, increment failure counter; if it succeeds, reset failure counter to 0
+- When failure counter reaches `failure_threshold`, transition to "open" state and record the time
+- In "open" state: `call()` raises `CircuitOpenError` without invoking `func`
+- After `recovery_timeout` seconds in "open" state, transition to "half-open" state
+- In "half-open" state: allow exactly one call through. If it succeeds, transition to "closed" and reset failure counter. If it fails, transition back to "open" and reset the timer
+- `state` property returns one of: "closed", "open", "half-open"
+- `CircuitOpenError` is a custom exception class defined in the same module
+- Uses `time.monotonic()` for time tracking
+
+## Examples
+```python
+cb = circuit_breaker(failure_threshold=2, recovery_timeout=1.0)
+assert cb.state == "closed"
+
+# Two failures trip the breaker
+try: cb.call(failing_func)
+except ValueError: pass
+try: cb.call(failing_func)
+except ValueError: pass
+assert cb.state == "open"
+```
+
+## Tests
+- test_starts_closed: initial state is "closed"
+- test_passes_through_on_success: successful calls return the result
+- test_opens_after_threshold: consecutive failures transition to "open"
+- test_blocks_in_open_state: raises CircuitOpenError without calling func
+- test_half_open_after_timeout: transitions to "half-open" after recovery_timeout (mock time.monotonic)

--- a/specs/debounce.md
+++ b/specs/debounce.md
@@ -1,0 +1,43 @@
+# Spec: debounce
+
+## Description
+A decorator that delays execution of the wrapped function. If the function
+is called again within the delay window, the previous pending call is cancelled
+and the timer resets. Uses threading for the delay.
+
+## Signature
+```python
+def debounce(delay: float) -> Callable:
+```
+
+## Behavior
+- Returns a decorator that wraps a function with debounce behavior
+- When the wrapped function is called, it does NOT execute immediately
+- Instead, it schedules execution after `delay` seconds
+- If the wrapped function is called again before `delay` has elapsed, the previous pending call is cancelled and a new timer starts
+- The function is called with the arguments from the LAST call (not the first)
+- Uses `threading.Timer` for scheduling
+- The decorated function has a `cancel()` method to cancel any pending call
+- The decorated function has a `flush()` method that immediately executes the pending call (if any) and cancels the timer
+- Thread-safe: concurrent calls are handled correctly
+
+## Examples
+```python
+results = []
+
+@debounce(0.1)
+def save(value):
+    results.append(value)
+
+save("a")
+save("b")  # cancels "a", schedules "b"
+time.sleep(0.2)
+assert results == ["b"]
+```
+
+## Tests
+- test_delays_execution: function not called immediately, called after delay
+- test_cancels_previous: rapid calls result in only the last call executing
+- test_uses_last_args: debounced call uses arguments from the most recent invocation
+- test_cancel_method: cancel() prevents pending execution
+- test_flush_method: flush() immediately executes pending call

--- a/specs/diff_json.md
+++ b/specs/diff_json.md
@@ -1,0 +1,40 @@
+# Spec: diff_json
+
+## Description
+Deep diff two JSON-serializable Python objects. Returns a list of changes
+describing what was added, removed, or modified between the two objects.
+
+## Signature
+```python
+def diff_json(old: object, new: object, path: str = "") -> list[dict]:
+```
+
+## Behavior
+- Compares `old` and `new` recursively and returns a list of change dicts
+- Each change dict has keys: `"op"` (one of "add", "remove", "change"), `"path"` (dot-separated path string), and relevant value keys
+- For `"add"`: `{"op": "add", "path": "...", "value": new_value}`
+- For `"remove"`: `{"op": "remove", "path": "...", "value": old_value}`
+- For `"change"`: `{"op": "change", "path": "...", "old": old_value, "new": new_value}`
+- Path uses dot notation for dict keys and bracket notation for list indices: e.g., `"users[0].name"`
+- Root-level path is an empty string `""`
+- Dict comparison: keys in new but not old are "add"; keys in old but not new are "remove"; keys in both with different values are recursed
+- List comparison: compares element by element up to the length of the shorter list; extra elements in new are "add"; extra elements in old are "remove"
+- Scalar comparison (str, int, float, bool, None): if not equal, produce a "change" entry
+- If old and new are equal (deeply), return an empty list
+- If old and new are different types at the same path, produce a "change" entry (do not recurse)
+
+## Examples
+```python
+old = {"name": "Alice", "age": 30}
+new = {"name": "Alice", "age": 31, "city": "NYC"}
+result = diff_json(old, new)
+# [{"op": "change", "path": "age", "old": 30, "new": 31},
+#  {"op": "add", "path": "city", "value": "NYC"}]
+```
+
+## Tests
+- test_no_changes: identical objects return empty list
+- test_scalar_change: top-level value change detected
+- test_nested_dict_change: change in nested dict uses dot path
+- test_list_add_remove: extra/missing list elements detected with bracket notation
+- test_type_mismatch: different types at same path produce "change" not recursion

--- a/specs/event_emitter.md
+++ b/specs/event_emitter.md
@@ -1,0 +1,50 @@
+# Spec: event_emitter
+
+## Description
+An event system supporting subscribe, emit, and unsubscribe. Handlers are
+called in registration order. Supports multiple handlers per event and
+one-time handlers.
+
+## Signature
+```python
+class event_emitter:
+    def __init__(self) -> None: ...
+    def on(self, event: str, handler: Callable) -> None: ...
+    def once(self, event: str, handler: Callable) -> None: ...
+    def emit(self, event: str, *args, **kwargs) -> None: ...
+    def off(self, event: str, handler: Callable) -> None: ...
+    def listeners(self, event: str) -> list[Callable]: ...
+```
+
+## Behavior
+- `on(event, handler)` registers a handler for the event; same handler can be registered multiple times
+- `once(event, handler)` registers a handler that is automatically removed after the first time it is called
+- `emit(event, *args, **kwargs)` calls all registered handlers for the event in registration order, passing args and kwargs
+- `emit` on an event with no handlers does nothing (no error)
+- `off(event, handler)` removes the first occurrence of handler for the event; raises ValueError if handler is not registered
+- `listeners(event)` returns a list of currently registered handlers for the event (excluding already-fired once handlers)
+
+## Examples
+```python
+ee = event_emitter()
+results = []
+ee.on("data", lambda x: results.append(x))
+ee.emit("data", 42)
+assert results == [42]
+```
+
+```python
+ee = event_emitter()
+results = []
+ee.once("ping", lambda: results.append("pong"))
+ee.emit("ping")
+ee.emit("ping")
+assert results == ["pong"]  # only called once
+```
+
+## Tests
+- test_on_and_emit: handler receives emitted arguments
+- test_multiple_handlers: handlers called in registration order
+- test_once_fires_once: once handler removed after first emit
+- test_off_removes_handler: unsubscribed handler is not called
+- test_off_nonexistent_raises: off with unregistered handler raises ValueError

--- a/specs/lru_cache.md
+++ b/specs/lru_cache.md
@@ -1,0 +1,44 @@
+# Spec: lru_cache
+
+## Description
+A class implementing a least-recently-used cache with a fixed maximum size.
+When the cache is full and a new key is inserted, the least recently accessed
+key is evicted. Both get and put operations count as access.
+
+## Signature
+```python
+class lru_cache:
+    def __init__(self, capacity: int) -> None: ...
+    def get(self, key: str) -> object | None: ...
+    def put(self, key: str, value: object) -> None: ...
+    def size(self) -> int: ...
+```
+
+## Behavior
+- `__init__` creates an empty cache with the given maximum capacity
+- `get(key)` returns the value if key exists, otherwise returns None
+- `get(key)` marks the key as most recently used
+- `put(key, value)` inserts or updates the key-value pair
+- `put(key, value)` marks the key as most recently used
+- When cache is full and a new key is inserted, the least recently used key is evicted
+- Updating an existing key does NOT count as inserting a new key (no eviction needed)
+- `size()` returns the current number of items in the cache
+- Do NOT use functools.lru_cache; implement from scratch using OrderedDict or similar
+
+## Examples
+```python
+cache = lru_cache(2)
+cache.put("a", 1)
+cache.put("b", 2)
+assert cache.get("a") == 1  # "a" is now most recently used
+cache.put("c", 3)           # evicts "b" (least recently used)
+assert cache.get("b") is None
+assert cache.get("c") == 3
+```
+
+## Tests
+- test_get_and_put: basic insert and retrieve
+- test_eviction_on_capacity: inserting beyond capacity evicts LRU key
+- test_get_updates_recency: accessing a key prevents it from being evicted
+- test_update_existing_key: updating existing key does not evict anything
+- test_size: size reflects current item count

--- a/specs/memoize_to_disk.md
+++ b/specs/memoize_to_disk.md
@@ -1,0 +1,40 @@
+# Spec: memoize_to_disk
+
+## Description
+A decorator that caches function results to disk as JSON files. Each unique
+set of arguments produces a separate cache file. Supports TTL-based expiration.
+
+## Signature
+```python
+def memoize_to_disk(cache_dir: str = ".cache", ttl: float | None = None) -> Callable:
+```
+
+## Behavior
+- Returns a decorator that wraps a function with disk-based memoization
+- Cache files are stored in `cache_dir` directory (created if it doesn't exist)
+- Cache key is derived from function name and arguments: `{func_name}_{hash}.json` where hash is a SHA-256 hex digest of the JSON-serialized arguments (first 16 chars)
+- Cache file contains JSON with keys: `"result"`, `"timestamp"` (Unix epoch float), `"args"`, `"kwargs"`
+- On cache hit (file exists and not expired): return cached result without calling function
+- On cache miss (file missing or expired): call function, store result, return it
+- If `ttl` is None, cache never expires
+- If `ttl` is a number, cache expires after `ttl` seconds (compare current time minus stored timestamp)
+- Arguments must be JSON-serializable; raise `TypeError` if they are not
+- The decorated function has a `clear_cache()` method that deletes all cache files for that function
+- Uses `time.time()` for timestamps
+
+## Examples
+```python
+@memoize_to_disk(cache_dir="/tmp/test_cache", ttl=60)
+def expensive(x):
+    return x * 2
+
+assert expensive(5) == 10  # computed and cached
+assert expensive(5) == 10  # returned from cache
+```
+
+## Tests
+- test_caches_result: second call returns cached value without re-executing function
+- test_ttl_expiration: expired cache triggers re-execution (mock time.time)
+- test_different_args_different_cache: different arguments produce different cache entries
+- test_clear_cache: clear_cache() removes all cache files for the function
+- test_non_serializable_args_raises: passing non-JSON-serializable args raises TypeError

--- a/specs/rate_limiter.md
+++ b/specs/rate_limiter.md
@@ -1,0 +1,45 @@
+# Spec: rate_limiter
+
+## Description
+A token bucket rate limiter. Tokens are added at a fixed rate up to a maximum
+bucket size. Each request consumes one token. If no tokens are available, the
+request is rejected.
+
+## Signature
+```python
+class rate_limiter:
+    def __init__(self, rate: float, capacity: int) -> None: ...
+    def allow(self) -> bool: ...
+    def tokens(self) -> float: ...
+```
+
+## Behavior
+- `__init__` creates a rate limiter with `rate` tokens added per second and a maximum `capacity`
+- The bucket starts full (tokens equal to capacity)
+- `allow()` returns True and consumes one token if at least one token is available
+- `allow()` returns False if no tokens are available
+- Tokens are refilled based on elapsed time since last check: `elapsed * rate`, capped at `capacity`
+- Token count can be fractional internally but `allow()` requires at least 1.0 token
+- `tokens()` returns the current number of tokens (after refill calculation) as a float
+- Uses `time.monotonic()` for time tracking
+
+## Examples
+```python
+limiter = rate_limiter(rate=10.0, capacity=5)
+# Starts with 5 tokens
+assert limiter.allow() is True  # 4 tokens left
+assert limiter.allow() is True  # 3 tokens left
+```
+
+```python
+limiter = rate_limiter(rate=1.0, capacity=1)
+assert limiter.allow() is True   # 0 tokens left
+assert limiter.allow() is False  # no tokens
+```
+
+## Tests
+- test_starts_full: new limiter allows up to capacity requests
+- test_rejects_when_empty: returns False after all tokens consumed
+- test_refills_over_time: after waiting, tokens are replenished (mock time.monotonic)
+- test_capacity_cap: tokens never exceed capacity even after long wait
+- test_tokens_returns_current_count: tokens() reflects remaining tokens after allow() calls

--- a/specs/topological_sort.md
+++ b/specs/topological_sort.md
@@ -1,0 +1,44 @@
+# Spec: topological_sort
+
+## Description
+Topological sort using Kahn's algorithm. Takes a directed acyclic graph
+represented as an adjacency list and returns nodes in a valid topological
+order. Raises an error if the graph contains a cycle.
+
+## Signature
+```python
+def topological_sort(graph: dict[str, list[str]]) -> list[str]:
+```
+
+## Behavior
+- `graph` is a dict mapping each node to a list of nodes it has edges TO (dependencies point from dependent to dependency)
+- Returns a list of all nodes in a valid topological order (every node appears before all nodes it points to)
+- If the graph is empty, return an empty list
+- All nodes referenced in edge lists must also be keys in the graph dict; if a target node is not a key, treat it as a node with no outgoing edges
+- If the graph contains a cycle, raise `CycleError` with a message that includes at least one node involved in the cycle
+- `CycleError` is a custom exception class defined in the same module
+- When multiple valid orderings exist, prefer alphabetical order among equally-valid choices (use a min-heap or sorted collection for the queue)
+- Uses Kahn's algorithm: compute in-degrees, start with zero in-degree nodes, repeatedly remove and process them
+
+## Examples
+```python
+graph = {
+    "a": ["b", "c"],
+    "b": ["d"],
+    "c": ["d"],
+    "d": [],
+}
+assert topological_sort(graph) == ["a", "b", "c", "d"]
+```
+
+```python
+graph = {"a": ["b"], "b": ["a"]}
+# Raises CycleError
+```
+
+## Tests
+- test_linear_chain: a -> b -> c -> d returns [a, b, c, d]
+- test_diamond: diamond dependency graph returns valid order
+- test_cycle_raises: graph with cycle raises CycleError
+- test_empty_graph: empty dict returns empty list
+- test_deterministic_order: among equally-valid nodes, alphabetical order is used

--- a/tests/test_spec_library.py
+++ b/tests/test_spec_library.py
@@ -1,0 +1,44 @@
+"""Tests that all spec files in the library parse correctly."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from spec.parser import SpecDocument, parse_spec
+
+SPECS_DIR = Path(__file__).parent.parent / "specs"
+
+EXPECTED_SPECS = [
+    "retry_with_backoff",
+    "lru_cache",
+    "rate_limiter",
+    "circuit_breaker",
+    "event_emitter",
+    "bounded_queue",
+    "debounce",
+    "memoize_to_disk",
+    "diff_json",
+    "topological_sort",
+]
+
+
+class TestSpecLibrary:
+    def test_all_specs_exist(self):
+        for name in EXPECTED_SPECS:
+            path = SPECS_DIR / f"{name}.md"
+            assert path.exists(), f"Missing spec: {path}"
+
+    @pytest.mark.parametrize("name", EXPECTED_SPECS)
+    def test_spec_parses(self, name: str):
+        doc = parse_spec(SPECS_DIR / f"{name}.md")
+        assert doc.name == name
+        assert doc.description
+        assert doc.signature
+        assert len(doc.behavior) >= 3
+        assert len(doc.test_names) >= 3
+
+    def test_total_spec_count(self):
+        specs = [p for p in SPECS_DIR.glob("*.md") if p.name != ".gitkeep"]
+        assert len(specs) == 10


### PR DESCRIPTION
## Summary
- Wrote 9 new spec files (retry_with_backoff already existed): lru_cache, rate_limiter, circuit_breaker, event_emitter, bounded_queue, debounce, memoize_to_disk, diff_json, topological_sort
- Each spec has: typed signature, 5+ behavior bullets, concrete examples, 5 named tests
- All 10 specs parse without error
- 12 new tests validating spec existence, parsing, and field completeness
- Full suite at 68/68

## Spec categories
| Category | Specs |
|----------|-------|
| Decorators | retry_with_backoff, debounce, memoize_to_disk |
| Data structures | lru_cache, bounded_queue |
| Patterns | circuit_breaker, event_emitter, rate_limiter |
| Algorithms | topological_sort, diff_json |

## Eval
Run `uv run spec run specs/ --max-attempts 3` to execute the full eval (requires ANTHROPIC_API_KEY). Results will be saved to `output/.results.json` and viewable via `uv run spec stats`.

## Test plan
- [x] `uv run pytest -v` — 68/68 pass
- [x] All 10 specs parse with all required fields populated
- [x] Each spec has ≥3 behavior bullets and ≥3 test names

Closes #5

🤖 Generated with [Claude Code](https://claude.com/claude-code)